### PR TITLE
Bugfix for Silver

### DIFF
--- a/porter-operator/roles/transportserverclaim/tasks/main.yml
+++ b/porter-operator/roles/transportserverclaim/tasks/main.yml
@@ -96,6 +96,7 @@
     host: '{{ secondary_cluster_api_host }}'
     state: '{{ state }}'
     definition: "{{ lookup('template', 'TransportServer.yaml.j2') }}"
+  when: secondary_cluster_enabled
 
 - name: '[{{ ansible_operator_meta.namespace }}] - {{ ansible_operator_meta.name }} Primary Cluster Endpoint - {{ state }}'
   vars:


### PR DESCRIPTION
The porter-operator image failed when cleaning up with the deletion of a TransportServerClaim in the Silver cluster.  This prevented the tscs from being deleted.