### PR TITLE
Ports count bugfix

### DIFF
--- a/porter-operator/roles/transportserverclaim/tasks/main.yml
+++ b/porter-operator/roles/transportserverclaim/tasks/main.yml
@@ -81,7 +81,7 @@
   - name: Set ports count
     set_fact:
       port_count: "{{ service_spec.resources[0].spec.ports | length | int }}"
-    when: service_spec.resources[0].spec.ports is defined
+    when: service_spec.resources[0] is defined and service_spec.resources[0].spec.ports is defined
 
   - name: '[{{ ansible_operator_meta.namespace }}] - {{ ansible_operator_meta.name }} Secondary Cluster Endpoint - {{ state }}'
     vars:

--- a/porter-operator/roles/transportserverclaim/tasks/main.yml
+++ b/porter-operator/roles/transportserverclaim/tasks/main.yml
@@ -81,6 +81,7 @@
   - name: Set ports count
     set_fact:
       port_count: "{{ service_spec.resources[0].spec.ports | length | int }}"
+    when: service_spec.resources[0].spec.ports is defined
 
   - name: '[{{ ansible_operator_meta.namespace }}] - {{ ansible_operator_meta.name }} Secondary Cluster Endpoint - {{ state }}'
     vars:


### PR DESCRIPTION
This addresses an oversight where the playbook would error out if the Service described in the TSC did not exist.