### PR TITLE
Service port override and requested port

### DIFF
--- a/porter-operator/roles/transportserverclaim/defaults/main.yml
+++ b/porter-operator/roles/transportserverclaim/defaults/main.yml
@@ -7,3 +7,4 @@ secondary_cluster_api_host: "{{ lookup('env', 'SECONDARY_CLUSTER_API_HOST') }}"
 primary_cluster_name: "{{ lookup('env', 'PRIMARY_CLUSTER_NAME') }}"
 secondary_cluster_name: "{{ lookup('env', 'SECONDARY_CLUSTER_NAME') }}"
 secondary_cluster_enabled: false
+use_requested_port: false

--- a/porter-operator/roles/transportserverclaim/defaults/main.yml
+++ b/porter-operator/roles/transportserverclaim/defaults/main.yml
@@ -8,3 +8,4 @@ primary_cluster_name: "{{ lookup('env', 'PRIMARY_CLUSTER_NAME') }}"
 secondary_cluster_name: "{{ lookup('env', 'SECONDARY_CLUSTER_NAME') }}"
 secondary_cluster_enabled: false
 use_requested_port: false
+override_service_port: false

--- a/porter-operator/roles/transportserverclaim/tasks/main.yml
+++ b/porter-operator/roles/transportserverclaim/tasks/main.yml
@@ -7,7 +7,7 @@
     - 'Namespace: {{ ansible_operator_meta.namespace }}'
     - 'ServicePort: {{ service_port }}'
     - 'Monitor: {{ monitor }}'
-    verbosity: 3
+    verbosity: 0
 
 - name: '[{{ ansible_operator_meta.namespace }}] - {{ ansible_operator_meta.name }} get port if exists'
   community.kubernetes.k8s_info:
@@ -20,7 +20,7 @@
 - name: '[{{ ansible_operator_meta.namespace }}] - {{ ansible_operator_meta.name }}'
   ansible.builtin.debug:
     var: transport_server
-    verbosity: 3
+    verbosity: 0
 
 - name: '[{{ ansible_operator_meta.namespace }}] - {{ ansible_operator_meta.name }} set f5_ingress_port'
   ansible.builtin.set_fact: 
@@ -38,7 +38,7 @@
     - name: '[{{ ansible_operator_meta.namespace }}] - {{ ansible_operator_meta.name }} request port uri debug'
       ansible.builtin.debug: 
         var: new_port_request
-        verbosity: 3
+        verbosity: 0
 
     # new_port_request.json isn't actually json, it's just the key the response goes into..
     - name: '[{{ ansible_operator_meta.namespace }}] - {{ ansible_operator_meta.name }} set f5_ingress_port'
@@ -49,7 +49,7 @@
 - name: '[{{ ansible_operator_meta.namespace }}] - {{ ansible_operator_meta.name }} show f5_ingress_port'
   ansible.builtin.debug: 
     var: f5_ingress_port
-    verbosity: 3
+    verbosity: 0
 
 - ansible.builtin.set_fact:
     secondary_cluster_enabled: true

--- a/porter-operator/roles/transportserverclaim/tasks/main.yml
+++ b/porter-operator/roles/transportserverclaim/tasks/main.yml
@@ -1,5 +1,7 @@
 ---
 # tasks file for TransportServerClaim
+# Parameters from the 'spec' of the TransportServerClaim are automatically
+#   converted from camelCase to snake_case, e.g. servicePort --> service_port
 - name: '[{{ ansible_operator_meta.namespace }}] - {{ ansible_operator_meta.name }} dump custom resource variables'
   ansible.builtin.debug:
     msg: 
@@ -9,17 +11,15 @@
     - 'Monitor: {{ monitor }}'
     #verbosity: 3
 
-- name: 'Debugging'
-  ansible.builtin.debug:
-    msg:
-    - 'RequestedPort: {{ spec.requested_port }}'
-  when: spec.requested_port is defined
-
-- name: 'Debugging'
-  ansible.builtin.debug:
-    msg:
-    - 'RequestedPort: {{ requested_port }}'
-  when: requested_port is defined
+- name: '[{{ ansible_operator_meta.namespace }}] - {{ ansible_operator_meta.name }} set use_requested_port'
+  when:
+    - requested_port is defined
+    - requested_port | type_debug == "int"
+    - requested_port is regex("^[0-9]+$")
+    - requested_port > lookup('env', 'MIN_PORT')
+    - requested_port < lookup('env', 'MAX_PORT')
+  ansible.builtin.set_fact:
+    use_requested_port: true
 
 - name: '[{{ ansible_operator_meta.namespace }}] - {{ ansible_operator_meta.name }} get port if exists'
   community.kubernetes.k8s_info:
@@ -39,24 +39,47 @@
     f5_ingress_port: '{{ transport_server.resources.0.spec.virtualServerPort }}'
   when: transport_server.resources | length != 0
 
+# If the TransportServerClaim has .spec.requestedPort set and it passed the
+#   tests above, call the API to confirm that the port is currently available.
+# If it is, set 'f5_ingress_port'.
+# If not, unset 'use_requested_port' and get the port in the normal way.
+# ----------------------------------------------------------------------------
+- name: '[{{ ansible_operator_meta.namespace }}] - {{ ansible_operator_meta.name }} if available, use requested port'
+  when:
+    - transport_server.resources | length == 0
+    - use_requested_port
+  block:
+    - name: '[{{ ansible_operator_meta.namespace }}] - {{ ansible_operator_meta.name }} check availability of requested port'
+      ansible.builtin.uri:
+        url: 'http://localhost:10000/isPortAvailable?port={{ requested_port }}'
+      register: requested_port_check
+
+    - name: '[{{ ansible_operator_meta.namespace }}] - {{ ansible_operator_meta.name }} set requested port'
+      when: requested_port_check.rc == 0
+      ansible.builtin.set_fact:
+        f5_ingress_port: '{{ requested_port }}'
+
+    - name: '[{{ ansible_operator_meta.namespace }}] - {{ ansible_operator_meta.name }} or deny requested port'
+      when: requested_port_check.rc != 0
+      ansible.builtin.set_fact:
+        use_requested_port: false
+
+# By default, assign a random available port
+# ------------------------------------------
 - name: '[{{ ansible_operator_meta.namespace }}] - {{ ansible_operator_meta.name }} request new port'
+  when:
+    - transport_server.resources | length == 0
+    - not use_requested_port
   block:
     - name: '[{{ ansible_operator_meta.namespace }}] - {{ ansible_operator_meta.name }} request port from sidecar'
       ansible.builtin.uri: 
         url: http://localhost:10000/claim
-        status_code: 200
       register: new_port_request
       
-    - name: '[{{ ansible_operator_meta.namespace }}] - {{ ansible_operator_meta.name }} request port uri debug'
-      ansible.builtin.debug: 
-        var: new_port_request
-        #verbosity: 3
-
     # new_port_request.json isn't actually json, it's just the key the response goes into..
     - name: '[{{ ansible_operator_meta.namespace }}] - {{ ansible_operator_meta.name }} set f5_ingress_port'
       ansible.builtin.set_fact: 
         f5_ingress_port: '{{ new_port_request.json }}'
-  when: transport_server.resources | length == 0
 
 - name: '[{{ ansible_operator_meta.namespace }}] - {{ ansible_operator_meta.name }} show f5_ingress_port'
   ansible.builtin.debug: 

--- a/porter-operator/roles/transportserverclaim/tasks/main.yml
+++ b/porter-operator/roles/transportserverclaim/tasks/main.yml
@@ -57,12 +57,12 @@
       register: requested_port_check
 
     - name: '[{{ ansible_operator_meta.namespace }}] - {{ ansible_operator_meta.name }} set requested port'
-      when: requested_port_check.rc == 0
+      when: requested_port_check.status == 200
       ansible.builtin.set_fact:
         f5_ingress_port: '{{ requested_port }}'
 
     - name: '[{{ ansible_operator_meta.namespace }}] - {{ ansible_operator_meta.name }} or deny requested port'
-      when: requested_port_check.rc != 0
+      when: requested_port_check.status != 200
       ansible.builtin.set_fact:
         use_requested_port: false
 

--- a/porter-operator/roles/transportserverclaim/tasks/main.yml
+++ b/porter-operator/roles/transportserverclaim/tasks/main.yml
@@ -7,6 +7,7 @@
     - 'Namespace: {{ ansible_operator_meta.namespace }}'
     - 'ServicePort: {{ service_port }}'
     - 'Monitor: {{ monitor }}'
+    - 'RequestedPort: {{ requested_port }}'
     #verbosity: 3
 
 - name: '[{{ ansible_operator_meta.namespace }}] - {{ ansible_operator_meta.name }} get port if exists'

--- a/porter-operator/roles/transportserverclaim/tasks/main.yml
+++ b/porter-operator/roles/transportserverclaim/tasks/main.yml
@@ -88,13 +88,13 @@
 # -----------------------------------------------------------------------------
 - name: '[{{ ansible_operator_meta.namespace }}] - {{ ansible_operator_meta.name }} Set TSC Service port'
   ansible.builtin.set_fact:
-    tsc_svc_port: f5_ingress_port | int
+    tsc_svc_port: "{{ f5_ingress_port }}"
 - name: '[{{ ansible_operator_meta.namespace }}] - {{ ansible_operator_meta.name }} Override TSC Service port'
   when:
     - override_service_port
     - override_service_port | type_debug == "bool"
   ansible.builtin.set_fact:
-    tsc_svc_port: service_port | int
+    tsc_svc_port: "{{ service_port }}"
 
 - name: '[{{ ansible_operator_meta.namespace }}] - {{ ansible_operator_meta.name }} show f5_ingress_port'
   ansible.builtin.debug: 

--- a/porter-operator/roles/transportserverclaim/tasks/main.yml
+++ b/porter-operator/roles/transportserverclaim/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 # tasks file for TransportServerClaim
-ansible.builtin.set_fact:
+- ansible.builtin.set_fact:
   min_port: "{{ lookup('env', 'MIN_PORT') }}"
   max_port: "{{ lookup('env', 'MAX_PORT') }}"
 

--- a/porter-operator/roles/transportserverclaim/tasks/main.yml
+++ b/porter-operator/roles/transportserverclaim/tasks/main.yml
@@ -88,13 +88,13 @@
 # -----------------------------------------------------------------------------
 - name: '[{{ ansible_operator_meta.namespace }}] - {{ ansible_operator_meta.name }} Set TSC Service port'
   ansible.builtin.set_fact:
-    tsc_svc_port: f5_ingress_port
+    tsc_svc_port: f5_ingress_port | int
 - name: '[{{ ansible_operator_meta.namespace }}] - {{ ansible_operator_meta.name }} Override TSC Service port'
   when:
     - override_service_port
     - override_service_port | type_debug == "bool"
   ansible.builtin.set_fact:
-    tsc_svc_port: service_port
+    tsc_svc_port: service_port | int
 
 - name: '[{{ ansible_operator_meta.namespace }}] - {{ ansible_operator_meta.name }} show f5_ingress_port'
   ansible.builtin.debug: 

--- a/porter-operator/roles/transportserverclaim/tasks/main.yml
+++ b/porter-operator/roles/transportserverclaim/tasks/main.yml
@@ -10,6 +10,18 @@
     - 'RequestedPort: {{ requested_port }}'
     #verbosity: 3
 
+- name: 'Debugging'
+  ansible.builtin.debug:
+    msg:
+    - 'RequestedPort: {{ spec.requested_port }}'
+  when: spec.requested_port is defined
+
+- name: 'Debugging'
+  ansible.builtin.debug:
+    msg:
+    - 'RequestedPort: {{ requested_port }}'
+  when: requested_port is defined
+
 - name: '[{{ ansible_operator_meta.namespace }}] - {{ ansible_operator_meta.name }} get port if exists'
   community.kubernetes.k8s_info:
     api_version: cis.f5.com/v1

--- a/porter-operator/roles/transportserverclaim/tasks/main.yml
+++ b/porter-operator/roles/transportserverclaim/tasks/main.yml
@@ -1,5 +1,9 @@
 ---
 # tasks file for TransportServerClaim
+ansible.builtin.set_fact:
+  min_port: "{{ lookup('env', 'MIN_PORT') }}"
+  max_port: "{{ lookup('env', 'MAX_PORT') }}"
+
 # Parameters from the 'spec' of the TransportServerClaim are automatically
 #   converted from camelCase to snake_case, e.g. servicePort --> service_port
 - name: '[{{ ansible_operator_meta.namespace }}] - {{ ansible_operator_meta.name }} dump custom resource variables'
@@ -9,15 +13,14 @@
     - 'Namespace: {{ ansible_operator_meta.namespace }}'
     - 'ServicePort: {{ service_port }}'
     - 'Monitor: {{ monitor }}'
-    #verbosity: 3
 
-- name: '[{{ ansible_operator_meta.namespace }}] - {{ ansible_operator_meta.name }} set use_requested_port'
+- name: '[{{ ansible_operator_meta.namespace }}] - {{ ansible_operator_meta.name }} set use_requested_port if valid'
   when:
     - requested_port is defined
     - requested_port | type_debug == "int"
     - requested_port is regex("^[0-9]+$")
-    - requested_port > lookup('env', 'MIN_PORT')
-    - requested_port < lookup('env', 'MAX_PORT')
+    - requested_port|int > min_port|int
+    - requested_port|int < max_port|int
   ansible.builtin.set_fact:
     use_requested_port: true
 
@@ -32,7 +35,6 @@
 - name: '[{{ ansible_operator_meta.namespace }}] - {{ ansible_operator_meta.name }}'
   ansible.builtin.debug:
     var: transport_server
-    #verbosity: 3
 
 - name: '[{{ ansible_operator_meta.namespace }}] - {{ ansible_operator_meta.name }} set f5_ingress_port'
   ansible.builtin.set_fact: 
@@ -42,7 +44,7 @@
 # If the TransportServerClaim has .spec.requestedPort set and it passed the
 #   tests above, call the API to confirm that the port is currently available.
 # If it is, set 'f5_ingress_port'.
-# If not, unset 'use_requested_port' and get the port in the normal way.
+# If not, unset 'use_requested_port' and get the port in the default way.
 # ----------------------------------------------------------------------------
 - name: '[{{ ansible_operator_meta.namespace }}] - {{ ansible_operator_meta.name }} if available, use requested port'
   when:

--- a/porter-operator/roles/transportserverclaim/tasks/main.yml
+++ b/porter-operator/roles/transportserverclaim/tasks/main.yml
@@ -5,7 +5,7 @@ ansible.builtin.set_fact:
   max_port: "{{ lookup('env', 'MAX_PORT') }}"
 
 # Parameters from the 'spec' of the TransportServerClaim are automatically
-#   converted from camelCase to snake_case, e.g. servicePort --> service_port
+# converted from camelCase to snake_case, e.g. servicePort --> service_port
 - name: '[{{ ansible_operator_meta.namespace }}] - {{ ansible_operator_meta.name }} dump custom resource variables'
   ansible.builtin.debug:
     msg: 
@@ -42,7 +42,7 @@ ansible.builtin.set_fact:
   when: transport_server.resources | length != 0
 
 # If the TransportServerClaim has .spec.requestedPort set and it passed the
-#   tests above, call the API to confirm that the port is currently available.
+# tests above, call the API to confirm that the port is currently available.
 # If it is, set 'f5_ingress_port'.
 # If not, unset 'use_requested_port' and get the port in the default way.
 # ----------------------------------------------------------------------------

--- a/porter-operator/roles/transportserverclaim/tasks/main.yml
+++ b/porter-operator/roles/transportserverclaim/tasks/main.yml
@@ -7,7 +7,6 @@
     - 'Namespace: {{ ansible_operator_meta.namespace }}'
     - 'ServicePort: {{ service_port }}'
     - 'Monitor: {{ monitor }}'
-    - 'RequestedPort: {{ requested_port }}'
     #verbosity: 3
 
 - name: 'Debugging'

--- a/porter-operator/roles/transportserverclaim/tasks/main.yml
+++ b/porter-operator/roles/transportserverclaim/tasks/main.yml
@@ -7,7 +7,7 @@
     - 'Namespace: {{ ansible_operator_meta.namespace }}'
     - 'ServicePort: {{ service_port }}'
     - 'Monitor: {{ monitor }}'
-    verbosity: 0
+    #verbosity: 3
 
 - name: '[{{ ansible_operator_meta.namespace }}] - {{ ansible_operator_meta.name }} get port if exists'
   community.kubernetes.k8s_info:
@@ -20,7 +20,7 @@
 - name: '[{{ ansible_operator_meta.namespace }}] - {{ ansible_operator_meta.name }}'
   ansible.builtin.debug:
     var: transport_server
-    verbosity: 0
+    #verbosity: 3
 
 - name: '[{{ ansible_operator_meta.namespace }}] - {{ ansible_operator_meta.name }} set f5_ingress_port'
   ansible.builtin.set_fact: 
@@ -38,7 +38,7 @@
     - name: '[{{ ansible_operator_meta.namespace }}] - {{ ansible_operator_meta.name }} request port uri debug'
       ansible.builtin.debug: 
         var: new_port_request
-        verbosity: 0
+        #verbosity: 3
 
     # new_port_request.json isn't actually json, it's just the key the response goes into..
     - name: '[{{ ansible_operator_meta.namespace }}] - {{ ansible_operator_meta.name }} set f5_ingress_port'
@@ -49,7 +49,7 @@
 - name: '[{{ ansible_operator_meta.namespace }}] - {{ ansible_operator_meta.name }} show f5_ingress_port'
   ansible.builtin.debug: 
     var: f5_ingress_port
-    verbosity: 0
+    #verbosity: 3
 
 - ansible.builtin.set_fact:
     secondary_cluster_enabled: true

--- a/porter-operator/roles/transportserverclaim/tasks/main.yml
+++ b/porter-operator/roles/transportserverclaim/tasks/main.yml
@@ -1,8 +1,8 @@
 ---
 # tasks file for TransportServerClaim
 - ansible.builtin.set_fact:
-  min_port: "{{ lookup('env', 'MIN_PORT') }}"
-  max_port: "{{ lookup('env', 'MAX_PORT') }}"
+    min_port: "{{ lookup('env', 'MIN_PORT') }}"
+    max_port: "{{ lookup('env', 'MAX_PORT') }}"
 
 # Parameters from the 'spec' of the TransportServerClaim are automatically
 # converted from camelCase to snake_case, e.g. servicePort --> service_port

--- a/porter-operator/roles/transportserverclaim/tasks/main.yml
+++ b/porter-operator/roles/transportserverclaim/tasks/main.yml
@@ -156,7 +156,7 @@
       state: '{{ state }}'
       definition: "{{ lookup('template', 'ServiceWithPort.yaml.j2') }}"
 
-# UPDATE STATUS
+# Update .status
 - name: '[{{ ansible_operator_meta.namespace }}] - {{ ansible_operator_meta.name }} status update'
   operator_sdk.util.k8s_status:
     api_version: porter.devops.gov.bc.ca/v1alpha1

--- a/porter-operator/roles/transportserverclaim/tasks/main.yml
+++ b/porter-operator/roles/transportserverclaim/tasks/main.yml
@@ -49,6 +49,9 @@
 # tests above, call the API to confirm that the port is currently available.
 # If it is, set 'f5_ingress_port'.
 # If not, unset 'use_requested_port' and get the port in the default way.
+#
+# Note: This feature has not been advertised to users, because we have given
+# them the 'overrideServicePort' option.
 # --------------------------------------------------------------------------
 - name: '[{{ ansible_operator_meta.namespace }}] - {{ ansible_operator_meta.name }} if available, use requested port'
   when:

--- a/porter-operator/roles/transportserverclaim/tasks/main.yml
+++ b/porter-operator/roles/transportserverclaim/tasks/main.yml
@@ -83,6 +83,19 @@
       ansible.builtin.set_fact: 
         f5_ingress_port: '{{ new_port_request.json }}'
 
+# Set tsc_svc_port to f5_ingress_port by default, but if overrideServicePort is
+# true, set it to the port of the target Service
+# -----------------------------------------------------------------------------
+- name: '[{{ ansible_operator_meta.namespace }}] - {{ ansible_operator_meta.name }} Set TSC Service port'
+  ansible.builtin.set_fact:
+    tsc_svc_port: f5_ingress_port
+- name: '[{{ ansible_operator_meta.namespace }}] - {{ ansible_operator_meta.name }} Override TSC Service port'
+  when:
+    - override_service_port
+    - override_service_port | type_debug == "bool"
+  ansible.builtin.set_fact:
+    tsc_svc_port: service_port
+
 - name: '[{{ ansible_operator_meta.namespace }}] - {{ ansible_operator_meta.name }} show f5_ingress_port'
   ansible.builtin.debug: 
     var: f5_ingress_port

--- a/porter-operator/roles/transportserverclaim/tasks/main.yml
+++ b/porter-operator/roles/transportserverclaim/tasks/main.yml
@@ -6,6 +6,7 @@
 
 # Parameters from the 'spec' of the TransportServerClaim are automatically
 # converted from camelCase to snake_case, e.g. servicePort --> service_port
+# -------------------------------------------------------------------------
 - name: '[{{ ansible_operator_meta.namespace }}] - {{ ansible_operator_meta.name }} dump custom resource variables'
   ansible.builtin.debug:
     msg: 
@@ -14,6 +15,9 @@
     - 'ServicePort: {{ service_port }}'
     - 'Monitor: {{ monitor }}'
 
+# If a specific port was requested, make sure it's valid or fall back to default
+# mode
+# ------------------------------------------------------------------------------
 - name: '[{{ ansible_operator_meta.namespace }}] - {{ ansible_operator_meta.name }} set use_requested_port if valid'
   when:
     - requested_port is defined
@@ -45,7 +49,7 @@
 # tests above, call the API to confirm that the port is currently available.
 # If it is, set 'f5_ingress_port'.
 # If not, unset 'use_requested_port' and get the port in the default way.
-# ----------------------------------------------------------------------------
+# --------------------------------------------------------------------------
 - name: '[{{ ansible_operator_meta.namespace }}] - {{ ansible_operator_meta.name }} if available, use requested port'
   when:
     - transport_server.resources | length == 0
@@ -83,9 +87,10 @@
       ansible.builtin.set_fact: 
         f5_ingress_port: '{{ new_port_request.json }}'
 
-# Set tsc_svc_port to f5_ingress_port by default, but if overrideServicePort is
-# true, set it to the port of the target Service
-# -----------------------------------------------------------------------------
+# If the TSC has '.spec.overrideServicePort: true', then use the port of the 
+# target Service by setting that value to 'tsc_svc_port'.
+# Otherwise, set tsc_svc_port to the same value as f5_ingress_port.
+# --------------------------------------------------------------------------
 - name: '[{{ ansible_operator_meta.namespace }}] - {{ ansible_operator_meta.name }} Set TSC Service port'
   ansible.builtin.set_fact:
     tsc_svc_port: "{{ f5_ingress_port }}"

--- a/porter-operator/roles/transportserverclaim/templates/Service.yaml.j2
+++ b/porter-operator/roles/transportserverclaim/templates/Service.yaml.j2
@@ -7,5 +7,5 @@ metadata:
 spec:
   ports:
     - protocol: TCP
-      port: {{ f5_ingress_port | int }}
+      port: {{ tsc_service_port | int }}
       targetPort: {{ f5_ingress_port | int }}

--- a/porter-operator/roles/transportserverclaim/templates/Service.yaml.j2
+++ b/porter-operator/roles/transportserverclaim/templates/Service.yaml.j2
@@ -7,5 +7,5 @@ metadata:
 spec:
   ports:
     - protocol: TCP
-      port: {{ tsc_service_port | int }}
+      port: {{ tsc_svc_port | int }}
       targetPort: {{ f5_ingress_port | int }}

--- a/porter-operator/roles/transportserverclaim/templates/ServiceWithPort.yaml.j2
+++ b/porter-operator/roles/transportserverclaim/templates/ServiceWithPort.yaml.j2
@@ -7,5 +7,5 @@ metadata:
 spec:
   ports:
     - protocol: TCP
-      port: {{ f5_ingress_port | int }}
+      port: {{ tsc_service_port | int }}
       targetPort: {{ f5_ingress_port | int }}

--- a/porter-operator/roles/transportserverclaim/templates/ServiceWithPort.yaml.j2
+++ b/porter-operator/roles/transportserverclaim/templates/ServiceWithPort.yaml.j2
@@ -7,5 +7,5 @@ metadata:
 spec:
   ports:
     - protocol: TCP
-      port: {{ tsc_service_port | int }}
+      port: {{ tsc_svc_port | int }}
       targetPort: {{ f5_ingress_port | int }}

--- a/portmap-api/main.go
+++ b/portmap-api/main.go
@@ -40,18 +40,6 @@ func main() {
 	fmt.Printf("MIN_PORT: %d - MAX_PORT: %d\n", minPort, maxPort)
 	portMap := pm.NewPortMap(minPort, maxPort)
 
-	// var kubeconfig *string
-	// if home := homedir.HomeDir(); home != "" {
-	// 	kubeconfig = flag.String("kubeconfig", filepath.Join(home, ".kube", "config"), "(optional) absolute path to the kubeconfig file")
-	// } else {
-	// 	kubeconfig = flag.String("kubeconfig", "", "absolute path to the kubeconfig file")
-	// }
-	// flag.Parse()
-
-	// config, err := clientcmd.BuildConfigFromFlags("", *kubeconfig)
-	// if err != nil {
-	// 	panic(err)
-	// }
 	config, err := rest.InClusterConfig()
 	if err != nil {
 		panic(err)

--- a/portmap-api/main.go
+++ b/portmap-api/main.go
@@ -68,25 +68,21 @@ func main() {
 		panic(err)
 	}
 
-	//fmt.Println("Adding Existing TransportServer VirtualServerPorts to Claimed Ports...")
 	pm.Logger("Adding Existing TransportServer VirtualServerPorts to Claimed Ports...")
 	for _, ts := range list.Items {
 		virtualServerPort, found, err := unstructured.NestedInt64(ts.Object, "spec", "virtualServerPort")
 		if err != nil || !found {
-			//fmt.Printf("virtualServerPort not found for TransportServer %s: error=%s", ts.GetName(), err)
 			logmsg = "virtualServerPort not found for TransportServer " + ts.GetName() + ": error=" + err.Error()
 			pm.Logger(logmsg)
 			continue
 		}
 
 		if portMap.ClaimPort(int(virtualServerPort)) {
-			//fmt.Printf(" * %s (claimed port: %d)\n", ts.GetName(), virtualServerPort)
-			logmsg = " * " + ts.GetName() + "(claimed port: " + strconv.FormatInt(virtualServerPort, 10) + ")"
+			logmsg = " " + strconv.FormatInt(virtualServerPort, 10) + "claimed by: " + ts.GetName()
 			pm.Logger(logmsg)
 			continue
 		}
 
-		//fmt.Printf("unable to claim virtualServerPort: %d", virtualServerPort)
 		logmsg = "unable to claim virtualServerPort: " + strconv.FormatInt(virtualServerPort, 10)
 		pm.Logger(logmsg)
 	}
@@ -95,6 +91,7 @@ func main() {
 	http.HandleFunc("/healthz", healthz)
 	http.HandleFunc("/claim", portMap.ClaimHandler)
 	http.HandleFunc("/relinquish", portMap.RelinquishHandler)
+	http.HandleFunc("/isPortAvailable", portMap.PortCheckHandler)
 
 	log.Fatal(http.ListenAndServe(":10000", nil))
 }

--- a/portmap-api/main.go
+++ b/portmap-api/main.go
@@ -66,7 +66,7 @@ func main() {
 		}
 
 		if portMap.ClaimPort(int(virtualServerPort)) {
-			logmsg = " " + strconv.FormatInt(virtualServerPort, 10) + "claimed by: " + ts.GetName()
+			logmsg = " " + strconv.FormatInt(virtualServerPort, 10) + " claimed by: " + ts.GetName()
 			pm.Logger(logmsg)
 			continue
 		}

--- a/portmap-api/portmap/portmap.go
+++ b/portmap-api/portmap/portmap.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"os"
 	"strconv"
 	"sync"
 	"time"

--- a/portmap-api/portmap/portmap.go
+++ b/portmap-api/portmap/portmap.go
@@ -144,4 +144,5 @@ func (p *PortMap) PortCheckHandler(w http.ResponseWriter, r *http.Request) {
 
 	// Otherwise, report that the requested port is available
 	fmt.Fprintf(w, "Port %d is available\n", port)
+
 }

--- a/portmap-api/portmap/portmap.go
+++ b/portmap-api/portmap/portmap.go
@@ -67,7 +67,6 @@ func (p *PortMap) RelinquishPort(port int) bool {
 func (p *PortMap) PrintClaimedPorts() {
 	for port, taken := range p.portMap {
 		if taken {
-			//fmt.Printf("* port: %d - taken: %t\n", port, taken)
 			logmsg := "* port: " + strconv.Itoa(port) + " - taken: " + strconv.FormatBool(taken)
 			Logger(logmsg)
 		}
@@ -76,7 +75,6 @@ func (p *PortMap) PrintClaimedPorts() {
 
 func (p *PortMap) ClaimHandler(w http.ResponseWriter, r *http.Request) {
 	if port, err := p.ClaimUnusedPort(); err == nil {
-		//fmt.Printf("* port %d claimed\n", port)
 		logmsg := "* port " + strconv.Itoa(port) + " claimed"
 		Logger(logmsg)
 		json.NewEncoder(w).Encode(port)
@@ -94,9 +92,56 @@ func (p *PortMap) RelinquishHandler(w http.ResponseWriter, r *http.Request) {
 
 	if p.portMap[port] {
 		p.portMap[port] = false
-		//fmt.Printf("* port %d relinquished\n", port)
 		logmsg := "* port " + strconv.Itoa(port) + " relinquished"
 		Logger(logmsg)
 		json.NewEncoder(w).Encode(port)
 	}
+}
+
+/*
+Users may want to know ahead of time if a certain port is available.  Provide an
+  API for this purpose.
+A successful request returns the port number and a response code of 200 (OK).
+If the port is not available, it returns a message with code 409 (Conflict).
+
+Examples:
+$ curl -w '%{response_code}\n' "http://localhost:9999/isPortAvailable?port=9999"
+Port 9999 is not available
+409
+
+$ curl --fail-with-body "http://localhost:9999/isPortAvailable?port=9999"
+Port 9999 is not available
+curl: (22) The requested URL returned error: 409
+
+$ curl -w '%{response_code}\n' "http://localhost:9999/isPortAvailable?port=9998"
+Port 9998 is available
+200
+*/
+func (p *PortMap) PortCheckHandler(w http.ResponseWriter, r *http.Request) {
+
+	portRequest := r.URL.Query().Get("port")
+
+	// Ensure that we got a port in the request
+	if portRequest == "" {
+		http.Error(w, "Port is missing from request.  Port should be in query string, such as: /isPortAvailable?port=12345", http.StatusBadRequest)
+		return
+	}
+
+	// Make sure that it is an integer and in the acceptable range
+	port, err := strconv.Atoi(portRequest)
+	if err != nil || port < minport || port > maxport {
+		errorMsg := fmt.Sprintf("Invalid port number: %d", port)
+		http.Error(w, errorMsg, http.StatusBadRequest)
+		return
+	}
+
+	// Report a conflict if the port is already in use
+	if p.portMap[port] {
+		errorMsg := fmt.Sprintf("Port %d is not available", port)
+		http.Error(w, errorMsg, http.StatusConflict)
+		return
+	}
+
+	// Otherwise, report that the requested port is available
+	fmt.Fprintf(w, "Port %d is available\n", port)
 }

--- a/portmap-api/portmap/portmap.go
+++ b/portmap-api/portmap/portmap.go
@@ -10,6 +10,11 @@ import (
 	"time"
 )
 
+var (
+	minPort, _ = strconv.Atoi(os.Getenv("MIN_PORT"))
+	maxPort, _ = strconv.Atoi(os.Getenv("MAX_PORT"))
+)
+
 type PortMap struct {
 	portMap map[int]bool
 	sync.Mutex
@@ -129,7 +134,7 @@ func (p *PortMap) PortCheckHandler(w http.ResponseWriter, r *http.Request) {
 
 	// Make sure that it is an integer and in the acceptable range
 	port, err := strconv.Atoi(portRequest)
-	if err != nil || port < minport || port > maxport {
+	if err != nil || port < minPort || port > maxPort {
 		errorMsg := fmt.Sprintf("Invalid port number: %d", port)
 		http.Error(w, errorMsg, http.StatusBadRequest)
 		return


### PR DESCRIPTION
Allow a user to set the target service port in the Service created by the operator so that they can connect to that Service using the standard port for the app.
Also allow a user to check to see if a certain port is in use and to specify it in the  TransportServerClaim, but we will not advertise this feature, because users will instead be directed to the port override.