### PR TITLE
Support NodePort types

### DIFF
--- a/porter-operator/roles/transportserverclaim/defaults/main.yml
+++ b/porter-operator/roles/transportserverclaim/defaults/main.yml
@@ -1,7 +1,9 @@
 ---
 # defaults file for TransportServerClaim
 primary_f5_ingress_ip: "{{ lookup('env', 'PRIMARY_F5_INGRESS_IP') }}"
+primary_f5_ingress_ip_nodeport: "{{ lookup('env', 'PRIMARY_F5_INGRESS_IP_NODEPORT') }}"
 secondary_f5_ingress_ip: "{{ lookup('env', 'SECONDARY_F5_INGRESS_IP') }}"
+secondary_f5_ingress_ip_nodeport: "{{ lookup('env', 'SECONDARY_F5_INGRESS_IP_NODEPORT') }}"
 secondary_cluster_api_key: "{{ lookup('env', 'SECONDARY_CLUSTER_API_KEY') }}"
 secondary_cluster_api_host: "{{ lookup('env', 'SECONDARY_CLUSTER_API_HOST') }}"
 primary_cluster_name: "{{ lookup('env', 'PRIMARY_CLUSTER_NAME') }}"

--- a/porter-operator/roles/transportserverclaim/tasks/main.yml
+++ b/porter-operator/roles/transportserverclaim/tasks/main.yml
@@ -116,8 +116,31 @@
     - secondary_cluster_name is defined
     - secondary_cluster_name != ""
 
-# Using a template due to definition requirements (Can't template integers inline)
-# https://github.com/operator-framework/operator-sdk/issues/1701
+# Check the Service type
+#   If NodePort
+#     - set label "f5cr" to "nodeport"
+#     - use NodePort IP address
+#   If ClusterIP
+#     - set label "f5cr" to "true"
+#     - use legacy IP address
+# ------------------------------------
+- name: '[{{ ansible_operator_meta.namespace }}] - {{ ansible_operator_meta.name }} get target Service info'
+  kubernetes.core.k8s_info:
+    kind: Service
+    api_version: v1
+    name: "{{ service }}"
+    namespace: "{{ ansible_operator_meta.namespace }}"
+  register: target_service_info
+- name: '[{{ ansible_operator_meta.namespace }}] - {{ ansible_operator_meta.name }} set f5cr label'
+  ansible.builtin.set_fact:
+    f5cr_label: "{{ (target_service_info.requests[0].spec.type == 'NodePort') | ternary('nodeport', 'true') }}"
+    primary_f5_ingress_ip: "{{ (target_service_info.requests[0].spec.type == 'NodePort') | ternary(primary_f5_ingress_ip_nodeport, primary_f5_ingress_ip) }}"
+    secondary_f5_ingress_ip: "{{ (target_service_info.requests[0].spec.type == 'NodePort') | ternary(secondary_f5_ingress_ip_nodeport, secondary_f5_ingress_ip) }}"
+  
+
+# Create TransportServer
+#   Using a template due to definition requirements (Can't template integers inline)
+#   https://github.com/operator-framework/operator-sdk/issues/1701
 - name: '[{{ ansible_operator_meta.namespace }}] - {{ ansible_operator_meta.name }} Primary Cluster TransportServer - {{ state }}'
   vars:
     f5_ingress_ip: '{{ primary_f5_ingress_ip }}'
@@ -128,18 +151,10 @@
 - name: Secondary cluster setup
   when: secondary_cluster_enabled
   block:
-  - name: Get Service specs
-    kubernetes.core.k8s_info:
-      api_version: v1
-      kind: Service
-      name: "{{ service }}"
-      namespace: "{{ ansible_operator_meta.namespace }}"
-    register: service_spec
-
   - name: Set ports count
     set_fact:
-      port_count: "{{ service_spec.resources[0].spec.ports | length | int }}"
-    when: service_spec.resources[0] is defined and service_spec.resources[0].spec.ports is defined
+      port_count: "{{ target_service_info.resources[0].spec.ports | length | int }}"
+    when: target_service_info.resources[0] is defined and target_service_info.resources[0].spec.ports is defined
 
   - name: '[{{ ansible_operator_meta.namespace }}] - {{ ansible_operator_meta.name }} Secondary Cluster Endpoint - {{ state }}'
     vars:

--- a/porter-operator/roles/transportserverclaim/tasks/main.yml
+++ b/porter-operator/roles/transportserverclaim/tasks/main.yml
@@ -132,9 +132,14 @@
     namespace: '{{ ansible_operator_meta.namespace }}'
   register: target_service_info
 
+# For the 'f5cr' label, 'true' gets converted to 'True' unless we force it
+- name: 'Force true to lower-case string'
+  ansible.builtin.set_fact:
+    f5cr_label_true: !!str true
+
 - name: '[{{ ansible_operator_meta.namespace }}] - {{ ansible_operator_meta.name }} set f5cr label'
   ansible.builtin.set_fact:
-    f5cr_label: "{{ (target_service_info.resources[0].spec.type == 'NodePort') | ternary('nodeport', 'true') }}"
+    f5cr_label: "{{ (target_service_info.resources[0].spec.type == 'NodePort') | ternary('nodeport', f5cr_label_true) }}"
     primary_f5_ingress_ip: "{{ (target_service_info.resources[0].spec.type == 'NodePort') | ternary(primary_f5_ingress_ip_nodeport, primary_f5_ingress_ip) }}"
     secondary_f5_ingress_ip: "{{ (target_service_info.resources[0].spec.type == 'NodePort') | ternary(secondary_f5_ingress_ip_nodeport, secondary_f5_ingress_ip) }}"
   

--- a/porter-operator/roles/transportserverclaim/tasks/main.yml
+++ b/porter-operator/roles/transportserverclaim/tasks/main.yml
@@ -134,9 +134,9 @@
 
 - name: '[{{ ansible_operator_meta.namespace }}] - {{ ansible_operator_meta.name }} set f5cr label'
   ansible.builtin.set_fact:
-    f5cr_label: "{{ target_service_info.requests[0].spec.type == 'NodePort' | ternary('nodeport', 'true') }}"
-    primary_f5_ingress_ip: "{{ target_service_info.requests[0].spec.type == 'NodePort' | ternary(primary_f5_ingress_ip_nodeport, primary_f5_ingress_ip) }}"
-    secondary_f5_ingress_ip: "{{ target_service_info.requests[0].spec.type == 'NodePort' | ternary(secondary_f5_ingress_ip_nodeport, secondary_f5_ingress_ip) }}"
+    f5cr_label: "{{ (target_service_info.resources[0].spec.type == 'NodePort') | ternary('nodeport', 'true') }}"
+    primary_f5_ingress_ip: "{{ (target_service_info.resources[0].spec.type == 'NodePort') | ternary(primary_f5_ingress_ip_nodeport, primary_f5_ingress_ip) }}"
+    secondary_f5_ingress_ip: "{{ (target_service_info.resources[0].spec.type == 'NodePort') | ternary(secondary_f5_ingress_ip_nodeport, secondary_f5_ingress_ip) }}"
   
 
 # Create TransportServer

--- a/porter-operator/roles/transportserverclaim/tasks/main.yml
+++ b/porter-operator/roles/transportserverclaim/tasks/main.yml
@@ -131,11 +131,12 @@
     name: '{{ service }}'
     namespace: '{{ ansible_operator_meta.namespace }}'
   register: target_service_info
+
 - name: '[{{ ansible_operator_meta.namespace }}] - {{ ansible_operator_meta.name }} set f5cr label'
   ansible.builtin.set_fact:
-    f5cr_label: "{{ (target_service_info.requests[0].spec.type == 'NodePort') | ternary('nodeport', 'true') }}"
-    primary_f5_ingress_ip: "{{ (target_service_info.requests[0].spec.type == 'NodePort') | ternary(primary_f5_ingress_ip_nodeport, primary_f5_ingress_ip) }}"
-    secondary_f5_ingress_ip: "{{ (target_service_info.requests[0].spec.type == 'NodePort') | ternary(secondary_f5_ingress_ip_nodeport, secondary_f5_ingress_ip) }}"
+    f5cr_label: "{{ target_service_info.requests[0].spec.type == 'NodePort' | ternary('nodeport', 'true') }}"
+    primary_f5_ingress_ip: "{{ target_service_info.requests[0].spec.type == 'NodePort' | ternary(primary_f5_ingress_ip_nodeport, primary_f5_ingress_ip) }}"
+    secondary_f5_ingress_ip: "{{ target_service_info.requests[0].spec.type == 'NodePort' | ternary(secondary_f5_ingress_ip_nodeport, secondary_f5_ingress_ip) }}"
   
 
 # Create TransportServer

--- a/porter-operator/roles/transportserverclaim/tasks/main.yml
+++ b/porter-operator/roles/transportserverclaim/tasks/main.yml
@@ -132,14 +132,9 @@
     namespace: '{{ ansible_operator_meta.namespace }}'
   register: target_service_info
 
-# For the 'f5cr' label, 'true' gets converted to 'True' unless we force it
-- name: 'Force true to lower-case string'
-  ansible.builtin.set_fact:
-    f5cr_label_true: !!str true
-
 - name: '[{{ ansible_operator_meta.namespace }}] - {{ ansible_operator_meta.name }} set f5cr label'
   ansible.builtin.set_fact:
-    f5cr_label: "{{ (target_service_info.resources[0].spec.type == 'NodePort') | ternary('nodeport', f5cr_label_true) }}"
+    f5cr_label: "{{ (target_service_info.resources[0].spec.type == 'NodePort') | ternary('nodeport', 'true') }}"
     primary_f5_ingress_ip: "{{ (target_service_info.resources[0].spec.type == 'NodePort') | ternary(primary_f5_ingress_ip_nodeport, primary_f5_ingress_ip) }}"
     secondary_f5_ingress_ip: "{{ (target_service_info.resources[0].spec.type == 'NodePort') | ternary(secondary_f5_ingress_ip_nodeport, secondary_f5_ingress_ip) }}"
   

--- a/porter-operator/roles/transportserverclaim/tasks/main.yml
+++ b/porter-operator/roles/transportserverclaim/tasks/main.yml
@@ -128,8 +128,8 @@
   kubernetes.core.k8s_info:
     kind: Service
     api_version: v1
-    name: "{{ service }}"
-    namespace: "{{ ansible_operator_meta.namespace }}"
+    name: '{{ service }}'
+    namespace: '{{ ansible_operator_meta.namespace }}'
   register: target_service_info
 - name: '[{{ ansible_operator_meta.namespace }}] - {{ ansible_operator_meta.name }} set f5cr label'
   ansible.builtin.set_fact:

--- a/porter-operator/roles/transportserverclaim/templates/TransportServer.yaml.j2
+++ b/porter-operator/roles/transportserverclaim/templates/TransportServer.yaml.j2
@@ -3,7 +3,7 @@ apiVersion: cis.f5.com/v1
 kind: TransportServer
 metadata:
   labels:
-    f5cr: "{{ f5cr_label }}"
+    f5cr: "{{ f5cr_label | lower }}"
   name: {{ ansible_operator_meta.name }}
   namespace: {{ ansible_operator_meta.namespace }}
 spec:

--- a/porter-operator/roles/transportserverclaim/templates/TransportServer.yaml.j2
+++ b/porter-operator/roles/transportserverclaim/templates/TransportServer.yaml.j2
@@ -3,7 +3,7 @@ apiVersion: cis.f5.com/v1
 kind: TransportServer
 metadata:
   labels:
-    f5cr: "true"
+    f5cr: "{{ f5cr_label }}"
   name: {{ ansible_operator_meta.name }}
   namespace: {{ ansible_operator_meta.namespace }}
 spec:


### PR DESCRIPTION
When a Service has a type of NodePort, set the label 'f5cr'  to 'nodeport' and use a different IP address.