### PR TITLE
Workaround for broken tscs

### DIFF
--- a/porter-operator/roles/transportserverclaim/tasks/main.yml
+++ b/porter-operator/roles/transportserverclaim/tasks/main.yml
@@ -134,10 +134,9 @@
 
 - name: '[{{ ansible_operator_meta.namespace }}] - {{ ansible_operator_meta.name }} set f5cr label'
   ansible.builtin.set_fact:
-    f5cr_label: "{{ (target_service_info.resources[0].spec.type == 'NodePort') | ternary('nodeport', 'true') }}"
-    primary_f5_ingress_ip: "{{ (target_service_info.resources[0].spec.type == 'NodePort') | ternary(primary_f5_ingress_ip_nodeport, primary_f5_ingress_ip) }}"
-    secondary_f5_ingress_ip: "{{ (target_service_info.resources[0].spec.type == 'NodePort') | ternary(secondary_f5_ingress_ip_nodeport, secondary_f5_ingress_ip) }}"
-  
+    f5cr_label: "{{ (target_service_info.resources and target_service_info.resources[0].spec.type == 'NodePort') | ternary('nodeport', 'true') }}"
+    primary_f5_ingress_ip: "{{ (target_service_info.resources and target_service_info.resources[0].spec.type == 'NodePort') | ternary(primary_f5_ingress_ip_nodeport, primary_f5_ingress_ip) }}"
+    secondary_f5_ingress_ip: "{{ (target_service_info.resources and target_service_info.resources[0].spec.type == 'NodePort') | ternary(secondary_f5_ingress_ip_nodeport, secondary_f5_ingress_ip) }}"
 
 # Create TransportServer
 #   Using a template due to definition requirements (Can't template integers inline)


### PR DESCRIPTION
Can't assume that a TransportServerClaim is configured with a Service that exists, so check the results of the Service check.