### PR TITLE
Add standalone mode

### DIFF
--- a/porter-operator/roles/transportserverclaim/defaults/main.yml
+++ b/porter-operator/roles/transportserverclaim/defaults/main.yml
@@ -12,8 +12,3 @@ secondary_cluster_enabled: false
 use_requested_port: false
 override_service_port: false
 
-# Users may set .spec.mode to Standalone in order to get a single-cluster TSC
-# in Gold like they can do in Silver.  This is for project sets that are just in
-# Gold and not in GoldDR, though any Gold project could set this to Standalone.
-# ------------------------------------------------------------------------------
-mode: "{{ mode | default('CrossCluster') }}"

--- a/porter-operator/roles/transportserverclaim/defaults/main.yml
+++ b/porter-operator/roles/transportserverclaim/defaults/main.yml
@@ -16,4 +16,4 @@ override_service_port: false
 # in Gold like they can do in Silver.  This is for project sets that are just in
 # Gold and not in GoldDR, though any Gold project could set this to Standalone.
 # ------------------------------------------------------------------------------
-tsc_mode: CrossCluster
+mode: "{{ mode | default('CrossCluster') }}"

--- a/porter-operator/roles/transportserverclaim/defaults/main.yml
+++ b/porter-operator/roles/transportserverclaim/defaults/main.yml
@@ -12,4 +12,5 @@ secondary_cluster_enabled: false
 secondary_state: "present"
 use_requested_port: false
 override_service_port: false
+port_count: 0
 

--- a/porter-operator/roles/transportserverclaim/defaults/main.yml
+++ b/porter-operator/roles/transportserverclaim/defaults/main.yml
@@ -9,6 +9,7 @@ secondary_cluster_api_host: "{{ lookup('env', 'SECONDARY_CLUSTER_API_HOST') }}"
 primary_cluster_name: "{{ lookup('env', 'PRIMARY_CLUSTER_NAME') }}"
 secondary_cluster_name: "{{ lookup('env', 'SECONDARY_CLUSTER_NAME') }}"
 secondary_cluster_enabled: false
+secondary_state: "present"
 use_requested_port: false
 override_service_port: false
 

--- a/porter-operator/roles/transportserverclaim/defaults/main.yml
+++ b/porter-operator/roles/transportserverclaim/defaults/main.yml
@@ -11,3 +11,9 @@ secondary_cluster_name: "{{ lookup('env', 'SECONDARY_CLUSTER_NAME') }}"
 secondary_cluster_enabled: false
 use_requested_port: false
 override_service_port: false
+
+# Users may set .spec.mode to Standalone in order to get a single-cluster TSC
+# in Gold like they can do in Silver.  This is for project sets that are just in
+# Gold and not in GoldDR, though any Gold project could set this to Standalone.
+# ------------------------------------------------------------------------------
+mode: CrossCluster

--- a/porter-operator/roles/transportserverclaim/defaults/main.yml
+++ b/porter-operator/roles/transportserverclaim/defaults/main.yml
@@ -16,4 +16,4 @@ override_service_port: false
 # in Gold like they can do in Silver.  This is for project sets that are just in
 # Gold and not in GoldDR, though any Gold project could set this to Standalone.
 # ------------------------------------------------------------------------------
-mode: CrossCluster
+tsc_mode: CrossCluster

--- a/porter-operator/roles/transportserverclaim/tasks/main.yml
+++ b/porter-operator/roles/transportserverclaim/tasks/main.yml
@@ -123,13 +123,13 @@
     - secondary_cluster_exists
     - tsc_mode != "standalone"
 
-  # If a TSC were changed from default mode to Standalone, remove the matching
-  # Service from the other cluster.
-  - name: Set state to absent for resources in secondary cluster for standalone TSCs
-    set_fact:
-      secondary_state: "absent"
-    when:
-      - not secondary_cluster_enabled
+# If a TSC were changed from default mode to Standalone, remove the matching
+# Service from the other cluster.
+- name: Set state to absent for resources in secondary cluster for standalone TSCs
+  set_fact:
+    secondary_state: "absent"
+  when:
+    - not secondary_cluster_enabled
 
 # Check the Service type
 #   If NodePort

--- a/porter-operator/roles/transportserverclaim/tasks/main.yml
+++ b/porter-operator/roles/transportserverclaim/tasks/main.yml
@@ -38,9 +38,9 @@
     namespace: '{{ ansible_operator_meta.namespace }}'
   register: transport_server
 
-- name: '[{{ ansible_operator_meta.namespace }}] - {{ ansible_operator_meta.name }}'
-  ansible.builtin.debug:
-    var: transport_server
+#- name: '[{{ ansible_operator_meta.namespace }}] - {{ ansible_operator_meta.name }}'
+#  ansible.builtin.debug:
+#    var: transport_server
 
 - name: '[{{ ansible_operator_meta.namespace }}] - {{ ansible_operator_meta.name }} set f5_ingress_port'
   ansible.builtin.set_fact: 
@@ -106,30 +106,30 @@
   ansible.builtin.set_fact:
     tsc_svc_port: "{{ service_port }}"
 
-- name: '[{{ ansible_operator_meta.namespace }}] - {{ ansible_operator_meta.name }} show f5_ingress_port'
-  ansible.builtin.debug: 
-    var: f5_ingress_port
-    #verbosity: 3
-
-- name: 'DEBUG: tsc_mode and secondary_cluster_enabled'
-  ansible.builtin.debug: 
-    msg:
-      - "tsc_mode: {{ tsc_mode }}"
-      - "secondary_cluster_enabled: {{ secondary_cluster_enabled }}"
-
+# Even if there is a secondary cluster, it won't necessarily be used.
+# For example, a namespace in Gold w/o a matching GoldDR namespace
+# -------------------------------------------------------------------
 - ansible.builtin.set_fact:
-    secondary_cluster_enabled: true
-    port_count: 1
+    secondary_cluster_exists: true
   when: 
     - secondary_cluster_name is defined
     - secondary_cluster_name != ""
+
+- ansible.builtin.set_fact:
+    secondary_cluster_enabled: true
+    secondary_state: "{{ state }}"
+    port_count: 1
+  when: 
+    - secondary_cluster_exists
     - tsc_mode != "standalone"
 
-- name: 'DEBUG2: tsc_mode and secondary_cluster_enabled'
-  ansible.builtin.debug: 
-    msg:
-      - "tsc_mode: {{ tsc_mode }}"
-      - "secondary_cluster_enabled: {{ secondary_cluster_enabled }}"
+  # If a TSC were changed from default mode to Standalone, remove the matching
+  # Service from the other cluster.
+  - name: Set state to absent for resources in secondary cluster for standalone TSCs
+    set_fact:
+      secondary_state: "absent"
+    when:
+      - ! secondary_cluster_enabled
 
 # Check the Service type
 #   If NodePort
@@ -153,9 +153,16 @@
     primary_f5_ingress_ip: "{{ (target_service_info.resources and target_service_info.resources[0].spec.type == 'NodePort') | ternary(primary_f5_ingress_ip_nodeport, primary_f5_ingress_ip) }}"
     secondary_f5_ingress_ip: "{{ (target_service_info.resources and target_service_info.resources[0].spec.type == 'NodePort') | ternary(secondary_f5_ingress_ip_nodeport, secondary_f5_ingress_ip) }}"
 
-# Create TransportServer
-#   Using a template due to definition requirements (Can't template integers inline)
+# Manage TransportServer (create/update/delete, depending on action of TSC)
+#   'state' is "present" when TSC is created or updated
+#   'state' is "absent"  when TSC is deleted
+#
+# However, if an existing TSC is changed from default mode (CrossCluster) to
+#   Standalone, then remove the resources from the secondary cluster.
+#
+# Using a template due to definition requirements (Can't template integers inline)
 #   https://github.com/operator-framework/operator-sdk/issues/1701
+# --------------------------------------------------------------------------------
 - name: '[{{ ansible_operator_meta.namespace }}] - {{ ansible_operator_meta.name }} Primary Cluster TransportServer - {{ state }}'
   vars:
     f5_ingress_ip: '{{ primary_f5_ingress_ip }}'
@@ -164,30 +171,33 @@
     definition: "{{ lookup('template', 'TransportServer.yaml.j2') }}"
 
 - name: Secondary cluster setup
-  when: secondary_cluster_enabled
+  when: secondary_cluster_exists
   block:
   - name: Set ports count
     set_fact:
       port_count: "{{ target_service_info.resources[0].spec.ports | length | int }}"
-    when: target_service_info.resources[0] is defined and target_service_info.resources[0].spec.ports is defined
+    when:
+      - target_service_info.resources[0] is defined
+      - target_service_info.resources[0].spec.ports is defined
+      - secondary_cluster_enabled
 
-  - name: '[{{ ansible_operator_meta.namespace }}] - {{ ansible_operator_meta.name }} Secondary Cluster Endpoint - {{ state }}'
+  - name: '[{{ ansible_operator_meta.namespace }}] - {{ ansible_operator_meta.name }} Secondary Cluster Endpoint - {{ secondary_state }}'
     vars:
       cluster_name: '{{ primary_cluster_name }}'
       f5_ingress_ip: '{{ primary_f5_ingress_ip }}'
     community.kubernetes.k8s:
       api_key: '{{ secondary_cluster_api_key }}'
       host: '{{ secondary_cluster_api_host }}'
-      state: '{{ state }}'
+      state: '{{ secondary_state }}'
       definition: "{{ lookup('template', 'Endpoint.yaml.j2') }}"
 
-  - name: '[{{ ansible_operator_meta.namespace }}] - {{ ansible_operator_meta.name }} Secondary Cluster Service - {{ state }}'
+  - name: '[{{ ansible_operator_meta.namespace }}] - {{ ansible_operator_meta.name }} Secondary Cluster Service - {{ secondary_state }}'
     vars:
       cluster_name: '{{ primary_cluster_name }}'
     community.kubernetes.k8s:
       api_key: '{{ secondary_cluster_api_key }}'
       host: '{{ secondary_cluster_api_host }}'
-      state: '{{ state }}'
+      state: '{{ secondary_state }}'
       definition: "{{ lookup('template', 'Service.yaml.j2') }}"
 
   # If the target Service has multiple ports configured, there could be two 
@@ -198,24 +208,24 @@
   # We do this in addition to the original Service template in order to maintain
   # backwards compatibility - at least for now.
   # ----------------------------------------------------------------------------
-  - name: '[{{ ansible_operator_meta.namespace }}] - {{ ansible_operator_meta.name }} Secondary Cluster Service - {{ state }}'
+  - name: '[{{ ansible_operator_meta.namespace }}] - {{ ansible_operator_meta.name }} Secondary Cluster Service - {{ secondary_state }}'
     when: port_count | int > 1 
     vars:
       cluster_name: '{{ primary_cluster_name }}'
     community.kubernetes.k8s:
       api_key: '{{ secondary_cluster_api_key }}'
       host: '{{ secondary_cluster_api_host }}'
-      state: '{{ state }}'
+      state: '{{ secondary_state }}'
       definition: "{{ lookup('template', 'ServiceWithPort.yaml.j2') }}"
 
   # BEGIN SECONDARY CLUSTER COMMS CONFIGURATION
-  - name: '[{{ ansible_operator_meta.namespace }}] - {{ ansible_operator_meta.name }} Secondary Cluster TransportServer - {{ state }}'
+  - name: '[{{ ansible_operator_meta.namespace }}] - {{ ansible_operator_meta.name }} Secondary Cluster TransportServer - {{ secondary_state }}'
     vars:
       f5_ingress_ip: '{{ secondary_f5_ingress_ip }}'
     community.kubernetes.k8s:
       api_key: '{{ secondary_cluster_api_key }}'
       host: '{{ secondary_cluster_api_host }}'
-      state: '{{ state }}'
+      state: '{{ secondary_state }}'
       definition: "{{ lookup('template', 'TransportServer.yaml.j2') }}"
 
   - name: '[{{ ansible_operator_meta.namespace }}] - {{ ansible_operator_meta.name }} Primary Cluster Endpoint - {{ state }}'

--- a/porter-operator/roles/transportserverclaim/tasks/main.yml
+++ b/porter-operator/roles/transportserverclaim/tasks/main.yml
@@ -123,8 +123,8 @@
     - secondary_cluster_exists
     - tsc_mode != "standalone"
 
-# If a TSC were changed from default mode to Standalone, remove the matching
-# Service from the other cluster.
+# If a TSC were changed from default mode to Standalone, remove resources
+# related to the secondary cluster.
 - name: Set state to absent for resources in secondary cluster for standalone TSCs
   set_fact:
     secondary_state: "absent"
@@ -158,7 +158,7 @@
 #   'state' is "absent"  when TSC is deleted
 #
 # However, if an existing TSC is changed from default mode (CrossCluster) to
-#   Standalone, then remove the resources from the secondary cluster.
+#   Standalone, then remove resources related to the secondary cluster.
 #
 # Using a template due to definition requirements (Can't template integers inline)
 #   https://github.com/operator-framework/operator-sdk/issues/1701

--- a/porter-operator/roles/transportserverclaim/tasks/main.yml
+++ b/porter-operator/roles/transportserverclaim/tasks/main.yml
@@ -3,6 +3,7 @@
 - ansible.builtin.set_fact:
     min_port: "{{ lookup('env', 'MIN_PORT') }}"
     max_port: "{{ lookup('env', 'MAX_PORT') }}"
+    mode: "{{ mode | lower }}"
 
 # Parameters from the 'spec' of the TransportServerClaim are automatically
 # converted from camelCase to snake_case, e.g. servicePort --> service_port
@@ -14,6 +15,7 @@
     - 'Namespace: {{ ansible_operator_meta.namespace }}'
     - 'ServicePort: {{ service_port }}'
     - 'Monitor: {{ monitor }}'
+    - 'Mode: {{ mode }}'
 
 # If a specific port was requested, make sure it's valid or fall back to default
 # mode
@@ -115,6 +117,7 @@
   when: 
     - secondary_cluster_name is defined
     - secondary_cluster_name != ""
+    - mode != "standalone"
 
 # Check the Service type
 #   If NodePort

--- a/porter-operator/roles/transportserverclaim/tasks/main.yml
+++ b/porter-operator/roles/transportserverclaim/tasks/main.yml
@@ -3,7 +3,7 @@
 - ansible.builtin.set_fact:
     min_port: "{{ lookup('env', 'MIN_PORT') }}"
     max_port: "{{ lookup('env', 'MAX_PORT') }}"
-    tsc_mode: "{{ (mode | lower) | default('crosscluster') }}"
+    tsc_mode: "{{ (mode | default('CrossCluster')) | lower }}"
 
 # Parameters from the 'spec' of the TransportServerClaim are automatically
 # converted from camelCase to snake_case, e.g. servicePort --> service_port

--- a/porter-operator/roles/transportserverclaim/tasks/main.yml
+++ b/porter-operator/roles/transportserverclaim/tasks/main.yml
@@ -3,7 +3,7 @@
 - ansible.builtin.set_fact:
     min_port: "{{ lookup('env', 'MIN_PORT') }}"
     max_port: "{{ lookup('env', 'MAX_PORT') }}"
-    mode: "{{ mode | lower }}"
+    tsc_mode: "{{ mode | lower }}"
 
 # Parameters from the 'spec' of the TransportServerClaim are automatically
 # converted from camelCase to snake_case, e.g. servicePort --> service_port
@@ -15,7 +15,7 @@
     - 'Namespace: {{ ansible_operator_meta.namespace }}'
     - 'ServicePort: {{ service_port }}'
     - 'Monitor: {{ monitor }}'
-    - 'Mode: {{ mode }}'
+    - 'Mode: {{ tsc_mode }}'
 
 # If a specific port was requested, make sure it's valid or fall back to default
 # mode
@@ -111,10 +111,10 @@
     var: f5_ingress_port
     #verbosity: 3
 
-- name: 'DEBUG: mode and secondary_cluster_enabled'
+- name: 'DEBUG: tsc_mode and secondary_cluster_enabled'
   ansible.builtin.debug: 
     msg:
-      - "mode: {{ mode }}"
+      - "tsc_mode: {{ tsc_mode }}"
       - "secondary_cluster_enabled: {{ secondary_cluster_enabled }}"
 
 - ansible.builtin.set_fact:
@@ -123,12 +123,12 @@
   when: 
     - secondary_cluster_name is defined
     - secondary_cluster_name != ""
-    - mode != "standalone"
+    - tsc_mode != "standalone"
 
-- name: 'DEBUG2: mode and secondary_cluster_enabled'
+- name: 'DEBUG2: tsc_mode and secondary_cluster_enabled'
   ansible.builtin.debug: 
     msg:
-      - "mode: {{ mode }}"
+      - "tsc_mode: {{ tsc_mode }}"
       - "secondary_cluster_enabled: {{ secondary_cluster_enabled }}"
 
 # Check the Service type

--- a/porter-operator/roles/transportserverclaim/tasks/main.yml
+++ b/porter-operator/roles/transportserverclaim/tasks/main.yml
@@ -129,7 +129,7 @@
     set_fact:
       secondary_state: "absent"
     when:
-      - ! secondary_cluster_enabled
+      - not secondary_cluster_enabled
 
 # Check the Service type
 #   If NodePort

--- a/porter-operator/roles/transportserverclaim/tasks/main.yml
+++ b/porter-operator/roles/transportserverclaim/tasks/main.yml
@@ -228,30 +228,30 @@
       state: '{{ secondary_state }}'
       definition: "{{ lookup('template', 'TransportServer.yaml.j2') }}"
 
-  - name: '[{{ ansible_operator_meta.namespace }}] - {{ ansible_operator_meta.name }} Primary Cluster Endpoint - {{ state }}'
+  - name: '[{{ ansible_operator_meta.namespace }}] - {{ ansible_operator_meta.name }} Primary Cluster Endpoint - {{ secondary_state }}'
     vars:
       cluster_name: '{{ secondary_cluster_name }}'
       f5_ingress_ip: '{{ secondary_f5_ingress_ip }}'
     community.kubernetes.k8s:
-      state: '{{ state }}'
+      state: '{{ secondary_state }}'
       definition: "{{ lookup('template', 'Endpoint.yaml.j2') }}"
 
-  - name: '[{{ ansible_operator_meta.namespace }}] - {{ ansible_operator_meta.name }} Primary Cluster Service - {{ state }}'
+  - name: '[{{ ansible_operator_meta.namespace }}] - {{ ansible_operator_meta.name }} Primary Cluster Service - {{ secondary_state }}'
     vars:
       cluster_name: '{{ secondary_cluster_name }}'
     community.kubernetes.k8s:
-      state: '{{ state }}'
+      state: '{{ secondary_state }}'
       definition: "{{ lookup('template', 'Service.yaml.j2') }}"
 
   # As above, create a second Service having the port in the name if the target
   # Service has more than one port configured.
   # ---------------------------------------------------------------------------
-  - name: '[{{ ansible_operator_meta.namespace }}] - {{ ansible_operator_meta.name }} Primary Cluster Service - {{ state }}'
+  - name: '[{{ ansible_operator_meta.namespace }}] - {{ ansible_operator_meta.name }} Primary Cluster Service - {{ secondary_state }}'
     when: port_count | int > 1
     vars:
       cluster_name: '{{ secondary_cluster_name }}'
     community.kubernetes.k8s:
-      state: '{{ state }}'
+      state: '{{ secondary_state }}'
       definition: "{{ lookup('template', 'ServiceWithPort.yaml.j2') }}"
 
 # Update .status

--- a/porter-operator/roles/transportserverclaim/tasks/main.yml
+++ b/porter-operator/roles/transportserverclaim/tasks/main.yml
@@ -111,6 +111,12 @@
     var: f5_ingress_port
     #verbosity: 3
 
+- name: 'DEBUG: mode and secondary_cluster_enabled'
+  ansible.builtin.debug: 
+    msg:
+      - "mode: {{ mode }}"
+      - "secondary_cluster_enabled: {{ secondary_cluster_enabled }}"
+
 - ansible.builtin.set_fact:
     secondary_cluster_enabled: true
     port_count: 1
@@ -118,6 +124,12 @@
     - secondary_cluster_name is defined
     - secondary_cluster_name != ""
     - mode != "standalone"
+
+- name: 'DEBUG2: mode and secondary_cluster_enabled'
+  ansible.builtin.debug: 
+    msg:
+      - "mode: {{ mode }}"
+      - "secondary_cluster_enabled: {{ secondary_cluster_enabled }}"
 
 # Check the Service type
 #   If NodePort

--- a/porter-operator/roles/transportserverclaim/tasks/main.yml
+++ b/porter-operator/roles/transportserverclaim/tasks/main.yml
@@ -3,7 +3,7 @@
 - ansible.builtin.set_fact:
     min_port: "{{ lookup('env', 'MIN_PORT') }}"
     max_port: "{{ lookup('env', 'MAX_PORT') }}"
-    tsc_mode: "{{ mode | lower }}"
+    tsc_mode: "{{ (mode | lower) | default('crosscluster') }}"
 
 # Parameters from the 'spec' of the TransportServerClaim are automatically
 # converted from camelCase to snake_case, e.g. servicePort --> service_port


### PR DESCRIPTION
Allow a TransportServerClaim to set .spec.mode to Standalone so that projects in Gold that do not have a GoldDR namespace can set up a TransportServer like Silver cluster (without the cross-cluster configuration).